### PR TITLE
PIP08: Limit buy back to 40000 PSC

### DIFF
--- a/PIPS/pip-008.md
+++ b/PIPS/pip-008.md
@@ -17,7 +17,7 @@ This PIP applies the next Monday 00:00 UTC after Escrow council balance becomes 
 This PIP cease to apply the next Monday 00:00 UTC after Escrow council balance has more than 80,000 DAI worth of ETH.
 
 ## Specification
-- PIP004: Limit partner buyback program to buy back 60,000 PSC maximum
+- PIP004: Limit partner buyback program to buy back 40,000 PSC maximum
 - PIP007: Limit budgets to 1000 DAI per month per circle
 - PIP007: Budgets can only be spent to reimburse expenses.
 - PIP005: Limit bounty budgets to 1000 DAI per month per circle. All the bounties which have ongoing work are still eligible to claim.


### PR DESCRIPTION
As per voting: https://acebusters.slack.com/archives/C75C00YJD/p1522657958000045

5 of 7 votes pro.
